### PR TITLE
Use variable for program name

### DIFF
--- a/urler.c
+++ b/urler.c
@@ -29,6 +29,19 @@
 
 #include "version.h"
 
+#define OUTPUT_URL      0  /* default */
+#define OUTPUT_SCHEME   1
+#define OUTPUT_USER     2
+#define OUTPUT_PASSWORD 3
+#define OUTPUT_OPTIONS  4
+#define OUTPUT_HOST     5
+#define OUTPUT_PORT     6
+#define OUTPUT_PATH     7
+#define OUTPUT_QUERY    8
+#define OUTPUT_FRAGMENT 9
+#define OUTPUT_ZONEID   10
+#define PROGNAME        "urler"
+
 static void help(const char *msg)
 {
   if(msg != NULL)
@@ -66,22 +79,9 @@ static void help(const char *msg)
 
 static void show_version(void)
 {
-  fputs("urler version " URLER_VERSION_TXT "\n", stdout);
+  fputs(PROGNAME " version " URLER_VERSION_TXT "\n", stdout);
   exit(0);
 }
-
-#define OUTPUT_URL      0  /* default */
-#define OUTPUT_SCHEME   1
-#define OUTPUT_USER     2
-#define OUTPUT_PASSWORD 3
-#define OUTPUT_OPTIONS  4
-#define OUTPUT_HOST     5
-#define OUTPUT_PORT     6
-#define OUTPUT_PATH     7
-#define OUTPUT_QUERY    8
-#define OUTPUT_FRAGMENT 9
-#define OUTPUT_ZONEID   10
-
 
 struct option {
   const char *url;
@@ -275,8 +275,9 @@ int main(int argc, const char **argv)
       curl_free(nurl);
     }
     else {
-      fprintf(stderr, "not enough input to show %s (urle -h for help)\n",
-              name);
+      fprintf(stderr, "not enough input to show %s (%s -h for help)\n",
+              name,
+              PROGNAME);
       exit_status = 1;
     }
   }
@@ -287,7 +288,8 @@ int main(int argc, const char **argv)
       curl_free(nurl);
     }
     else {
-      fprintf(stderr, "not enough input for a URL (urle -h for help)\n");
+      fprintf(stderr, "not enough input for a URL (%s -h for help)\n",
+              PROGNAME);
       exit_status = 1;
     }
   }


### PR DESCRIPTION
Extract `PROGNAME` variable to hold the program name.

It fixes a typo in the current code, and it will help change the name if decided (re. #1).