### PR TITLE
Makefile: create man1 directory if missing; install manpage to DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ $(TARGET): $(OBJS)
 install:
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
-	install -d $(MANDIR)/man1/
-	install -m 0744 $(MANUAL) $(MANDIR)/man1/
+	install -d $(DESTDIR)$(MANDIR)/man1/
+	install -m 0744 $(MANUAL) $(DESTDIR)$(MANDIR)/man1/
 
 clean:
 	rm -f $(OBJS) $(TARGET)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ $(TARGET): $(OBJS)
 install:
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+	install -d $(MANDIR)/man1/
 	install -m 0744 $(MANUAL) $(MANDIR)/man1/
 
 clean:


### PR DESCRIPTION
Currently, installation will fail if `$(MANDIR)/man1/` does not exist. Fix that by creating the directory first.

Also, since the manpage is a `install` target, make sure it follows `DESTDIR`.
