### PR TITLE
add error handling for when no arguments passed for options at the end of command

### DIFF
--- a/urler.c
+++ b/urler.c
@@ -279,11 +279,8 @@ int main(int argc, const char **argv)
     else if(argv[0][0] == '-' && argv[0][1] == '-') {
       /* dash-dash prefixed */
       int usedarg = 0;
-      if(argc < 2) {
-          help("Invalid Arguments passed");
-          return -1;
-      }
-      if(getlongarg(&o, argv[0], argv[1], &usedarg))
+      
+      if(argc < 2 || getlongarg(&o, argv[0], argv[1], &usedarg))
         help("unknown option");
 
       if(usedarg) {

--- a/urler.c
+++ b/urler.c
@@ -279,6 +279,10 @@ int main(int argc, const char **argv)
     else if(argv[0][0] == '-' && argv[0][1] == '-') {
       /* dash-dash prefixed */
       int usedarg = 0;
+      if(argc < 2) {
+          help("Invalid Arguments passed");
+          return -1;
+      }
       if(getlongarg(&o, argv[0], argv[1], &usedarg))
         help("unknown option");
 

--- a/urler.c
+++ b/urler.c
@@ -164,16 +164,22 @@ static int getlongarg(struct option *op,
     show_version();
   if(!strcmp("--url", flag)) {
     if(arg == NULL) {
-        help("No url passed");
+        help("No url provided");
     }
     urladd(op, arg);
     *usedarg = 1;
   }
   else if(!strcmp("--append-path", flag)) {
+    if(arg == NULL) {
+        help("No path provided");
+    }
     pathadd(op, arg);
     *usedarg = 1;
   }
   else if(!strcmp("--append-query", flag)) {
+    if(arg == NULL) {
+        help("No query provided");
+    }
     queryadd(op, arg);
     *usedarg = 1;
   }

--- a/urler.c
+++ b/urler.c
@@ -163,6 +163,9 @@ static int getlongarg(struct option *op,
   if(!strcmp("--version", flag))
     show_version();
   if(!strcmp("--url", flag)) {
+    if(arg == NULL) {
+        help("No url passed");
+    }
     urladd(op, arg);
     *usedarg = 1;
   }
@@ -279,8 +282,7 @@ int main(int argc, const char **argv)
     else if(argv[0][0] == '-' && argv[0][1] == '-') {
       /* dash-dash prefixed */
       int usedarg = 0;
-      
-      if(argc < 2 || getlongarg(&o, argv[0], argv[1], &usedarg))
+      if(getlongarg(&o, argv[0], argv[1], &usedarg))
         help("unknown option");
 
       if(usedarg) {


### PR DESCRIPTION
master currently segfaults if you run `urler --url`, this is a quick fix so let me know if there should be more careful considerations taken. Note that this is different from #16 not sure what is different from testing but mine still seg faults if no URL passed. 
