### PR TITLE
Makefile: add a default `PREFIX`; create `MANDIR` before installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ LDLIBS = -lcurl
 CFLAGS := $(CFLAGS) -W -Wall -pedantic -g
 MANUAL = urler.1
 
-BINDIR ?= $(DESTDIR)$(prefix)/bin
-MANDIR ?= $(DESTDIR)$(prefix)/share/man/man1
+PREFIX ?= /usr/local
+BINDIR ?= $(DESTDIR)$(PREFIX)/bin
+MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
 
 $(TARGET): $(OBJS)
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ $(TARGET): $(OBJS)
 install:
 	install -d $(BINDIR)
 	install -m 0755 $(TARGET) $(BINDIR)
+	install -d $(MANDIR)
 	install -m 0744 $(MANUAL) $(MANDIR)
 
 clean:


### PR DESCRIPTION
This again addresses a `/usr/local/share/man/man1: No such file or directory` issue that was re-introduced by #17. (Sorry for the back and forth.)
