### PR TITLE
urler: if the path ends with a slash, don't add another one

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -10,6 +10,7 @@ my @t = (
     "https://example.com/../moo|https://example.com/moo",
     "https://example.com/.././moo|https://example.com/moo",
     "https://example.com/test/../moo|https://example.com/moo",
+    "localhost --append-path moo|http://localhost/moo",
 );
 
 for my $c (@t) {
@@ -19,8 +20,8 @@ for my $c (@t) {
     chomp $result;
     if($result ne $o) {
         print "FAIL\n";
-        print "$i did not make $o\n";
-        print "$result\n";
+        print "$i did not show \"$o\"\n";
+        print "It showed \"$result\"\n";
         exit 1;
     }
 }

--- a/urler.c
+++ b/urler.c
@@ -427,11 +427,18 @@ int main(int argc, const char **argv)
       char *apath = p->data;
       char *opath;
       char *npath;
+      size_t olen;
       /* extract the current path */
       curl_url_get(uh, CURLUPART_PATH, &opath, 0);
 
+      /* does the existing path end with a slash, then don't
+         add one inbetween */
+      olen = strlen(opath);
+
       /* append the new segment */
-      npath = curl_maprintf("%s/%s", opath, apath);
+      npath = curl_maprintf("%s%s%s", opath,
+                            opath[olen-1] == '/' ? "" : "/",
+                            apath);
       if(npath) {
         /* set the new path */
         curl_url_set(uh, CURLUPART_PATH, npath, 0);


### PR DESCRIPTION
When `--append-path` is used. Added a test for it.