### PR TITLE
added libcurl version to --version output

### DIFF
--- a/urler.c
+++ b/urler.c
@@ -67,7 +67,8 @@ static void help(const char *msg)
 
 static void show_version(void)
 {
-  fputs(PROGNAME " version " URLER_VERSION_TXT "\n", stdout);
+  curl_version_info_data *data = curl_version_info(CURLVERSION_NOW);
+  fprintf(stdout, "%s version %s libcurl/%s\n", PROGNAME, URLER_VERSION_TXT, data->version);
   exit(0);
 }
 


### PR DESCRIPTION
adds the version of libcurl to the `--version` output. meant to look similar to `curl --version`. 
```
$ urler --version
urler version 0.1 libcurl/7.87.0 
```

should close #28 